### PR TITLE
[App/#37] 페이지네이션 인피니트 스크롤 적용 

### DIFF
--- a/apps/asterum_traveler-admin/src/pages/landing/LandingImgFileUploader.tsx
+++ b/apps/asterum_traveler-admin/src/pages/landing/LandingImgFileUploader.tsx
@@ -76,7 +76,7 @@ const ImgPreviewContainer = styled.div`
     & > img {
       width: inherit;
       aspect-ratio: 1920/1080;
-      object-fit: fill;
+      object-fit: cover;
     }
   }
 

--- a/apps/asterum_traveler-admin/src/pages/report/ReportEditPage.tsx
+++ b/apps/asterum_traveler-admin/src/pages/report/ReportEditPage.tsx
@@ -21,7 +21,7 @@ function ReportEditPage() {
   const [thumbnail, setThumbnail] = useState<File | null>(null);
   const [displayDate, setDisplayDate] = useState<string>('');
   const [usageDate, setUsageDate] = useState<string>('');
-  const [category, setCategory] = useState<ReportCategory>('etc');
+  const [category, setCategory] = useState<ReportCategory[]>([]);
   const [liveTitle, setLiveTitle] = useState<string>('');
   const [tag, setTag] = useState<string>('');
   const [imageTags, setImageTags] = useState<string[]>([]);
@@ -72,6 +72,20 @@ function ReportEditPage() {
       prevMembers.includes(selectedMember)
         ? prevMembers.filter((member: Member) => member !== selectedMember) // 제거
         : [...prevMembers, selectedMember]
+    );
+  };
+
+  /**
+   * 게시글 카테고리 선택 변경
+   * @param {React.ChangeEvent<HTMLFormElement>} e
+   */
+  const changeSelectCategory = (e: React.ChangeEvent<HTMLFormElement>) => {
+    const selectedCategory = e.target.value;
+
+    setCategory((prevCategories) =>
+      prevCategories.includes(selectedCategory)
+        ? prevCategories.filter((category: ReportCategory) => category !== selectedCategory) // 제거
+        : [...prevCategories, selectedCategory]
     );
   };
 
@@ -219,50 +233,25 @@ function ReportEditPage() {
           </InputWrapper>
           <InputWrapper>
             <InfoLabel>게시글 카테고리</InfoLabel>
-            <form onChange={(e: React.ChangeEvent<HTMLFormElement>) => setCategory(e.target.value)}>
+            <form onChange={(e: React.ChangeEvent<HTMLFormElement>) => changeSelectCategory(e)}>
               <label>
-                <input
-                  type="radio"
-                  name="category"
-                  value="album"
-                  defaultChecked={category === 'album'}
-                />
+                <input type="checkbox" name="category" value="album" />
                 앨범
               </label>
               <label>
-                <input
-                  type="radio"
-                  name="category"
-                  value="fashion"
-                  defaultChecked={category === 'fashion'}
-                />
+                <input type="checkbox" name="category" value="fashion" />
                 패션
               </label>
               <label>
-                <input
-                  type="radio"
-                  name="category"
-                  value="game"
-                  defaultChecked={category === 'game'}
-                />
+                <input type="checkbox" name="category" value="game" />
                 게임
               </label>
               <label>
-                <input
-                  type="radio"
-                  name="category"
-                  value="live"
-                  defaultChecked={category === 'live'}
-                />
+                <input type="checkbox" name="category" value="live" />
                 라이브
               </label>
               <label>
-                <input
-                  type="radio"
-                  name="category"
-                  value="etc"
-                  defaultChecked={category === 'etc'}
-                />
+                <input type="checkbox" name="category" value="etc" />
                 기타
               </label>
             </form>
@@ -366,6 +355,7 @@ function ReportEditPage() {
               src={product.productThumbnail}
               onClick={() => changeSelectProduct(product.id)}
             />
+            <ProductName>{product.productBrand}</ProductName>
             <ProductName>{product.productName}</ProductName>
             <form
               onChange={(e: React.ChangeEvent<HTMLFormElement>) =>

--- a/apps/asterum_traveler-admin/src/shared/services/reportService.ts
+++ b/apps/asterum_traveler-admin/src/shared/services/reportService.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
 import { db, storage } from '../firebaseConfig';
-import { collection, doc, getDocs, query, setDoc, Timestamp } from 'firebase/firestore';
+import { collection, doc, getDocs, orderBy, query, setDoc, Timestamp } from 'firebase/firestore';
 import { Product, Report, ReportBase, ProductBase } from '@asterum/types';
 
 export const imageUpload = async (image: File, saveType: 'products' | 'reports') => {
@@ -78,7 +78,7 @@ export async function addReport(report: ReportBase): Promise<string> {
  */
 export async function getReports(): Promise<Report[]> {
   try {
-    const q = query(collection(db, 'reports'));
+    const q = query(collection(db, 'reports'), orderBy('reportDateUsage', 'desc'));
 
     const querySnapshot = await getDocs(q);
     const reports: Report[] = querySnapshot.docs.map((doc) => {

--- a/apps/asterum_traveler-app/src/App.tsx
+++ b/apps/asterum_traveler-app/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
 
   return (
     <ChakraProvider theme={theme}>
-      <Wrapper ref={wrapperRef} className="scrollbar">
+      <Wrapper ref={wrapperRef} className="scrollbar" id="scrollRoot">
         <Header scrollTarget={wrapperRef} />
         <Container>
           <PageContainer>

--- a/apps/asterum_traveler-app/src/components/dear/LettersView.tsx
+++ b/apps/asterum_traveler-app/src/components/dear/LettersView.tsx
@@ -1,21 +1,34 @@
 import { styled } from 'styled-components';
 import Card from './Card';
-import { useQuery } from '@tanstack/react-query';
-import { DearCard } from '@asterum/types';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import * as api from '../../shared/services/dearService';
+import { DearCard } from '@asterum/types';
+import InfiniteScroll from '../global/InfiniteScroll';
 
 function LettersView() {
-  const { data: dearCards } = useQuery<DearCard[]>({
+  const { data, isFetchingNextPage, fetchNextPage, hasNextPage } = useInfiniteQuery({
     queryKey: ['cards'],
     queryFn: api.getDearCards,
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => lastPage.lastPage || undefined,
+    staleTime: 1000 * 60 * 5,
   });
 
   return (
-    <Wrapper>
-      {dearCards?.map((dearCard) => (
-        <Card key={`card-${dearCard.id}`} dearCard={dearCard} />
-      ))}
-    </Wrapper>
+    <>
+      <Wrapper>
+        {data?.pages
+          .flatMap((page) => page.data)
+          .map((dearCard: DearCard) => (
+            <Card key={`card-${dearCard.id}`} dearCard={dearCard} />
+          ))}
+      </Wrapper>
+      <InfiniteScroll
+        fetchFn={fetchNextPage}
+        isLoaded={isFetchingNextPage}
+        isLastPage={!!!hasNextPage}
+      />
+    </>
   );
 }
 
@@ -24,6 +37,8 @@ const Wrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 16px;
+  min-height: 100%;
+  grid-template-rows: repeat(auto-fill, 388px);
 `;
 
 export default LettersView;

--- a/apps/asterum_traveler-app/src/components/global/InfiniteScroll.tsx
+++ b/apps/asterum_traveler-app/src/components/global/InfiniteScroll.tsx
@@ -1,0 +1,65 @@
+import { motion } from 'framer-motion';
+import { RefObject, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import logo from '../../assets/images/logos/logo_small.svg';
+
+const OPTIONS = {
+  rootMargin: '10px', // 바깥 여백(Margin)을 이용해 Root 범위를 확장하거나 축소할 수 있음
+  threshold: 1.0, // observer의 콜백이 실행될 대상 요소의 가시성 퍼센티지를 나타내는 단일 숫자 혹은 숫자 배열
+};
+
+interface InfiniteScrollProps {
+  parent?: RefObject<HTMLDivElement | null>;
+  fetchFn: () => {};
+  isLoaded: boolean;
+  isLastPage: boolean;
+}
+
+function InfiniteScroll({ parent, fetchFn, isLoaded, isLastPage }: InfiniteScrollProps) {
+  const targetRef = useRef(null);
+
+  useEffect(() => {
+    if (!targetRef.current || isLoaded) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          fetchFn();
+        }
+      },
+      { root: parent ? parent.current : document.querySelector('#scrollRoot'), ...OPTIONS }
+    );
+
+    observer.observe(targetRef.current);
+    return () => observer.disconnect();
+  }, [targetRef, isLoaded]);
+
+  return (
+    <Target ref={targetRef}>
+      {!isLastPage && isLoaded && (
+        <LoadingIcon
+          src={logo}
+          animate={{ rotate: 360 }}
+          transition={{ repeat: Infinity, duration: 1 }}
+        />
+      )}
+    </Target>
+  );
+}
+
+const Target = styled.div`
+  width: 100%;
+  min-height: 128px;
+  background: transparent;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const LoadingIcon = styled(motion.img)`
+  width: 48px;
+  height: 48px;
+  margin: 64px 0;
+`;
+
+export default InfiniteScroll;

--- a/apps/asterum_traveler-app/src/components/landing/CarouselImg.tsx
+++ b/apps/asterum_traveler-app/src/components/landing/CarouselImg.tsx
@@ -1,0 +1,34 @@
+import { SliderImage } from '@asterum/types';
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+interface CarouselImgProps {
+  image: SliderImage;
+}
+function CarouselImg({ image }: CarouselImgProps) {
+  const [loaded, setLoaded] = useState<boolean>(false);
+
+  return (
+    <Imgae
+      src={image.imageUrl}
+      width={1920}
+      height={1080}
+      alt="플레이브 이미지"
+      onLoad={() => {
+        setLoaded(true);
+      }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: loaded ? 1 : 0 }}
+      transition={{ duration: 0.7 }}
+    />
+  );
+}
+
+const Imgae = styled(motion.img)`
+  width: 1920px;
+  height: 1080px;
+  object-fit: cover;
+`;
+
+export default CarouselImg;

--- a/apps/asterum_traveler-app/src/components/landing/ImgSlider.tsx
+++ b/apps/asterum_traveler-app/src/components/landing/ImgSlider.tsx
@@ -3,6 +3,7 @@ import 'react-responsive-carousel/lib/styles/carousel.min.css';
 import { Carousel } from 'react-responsive-carousel';
 import * as api from '../../shared/services/landingService';
 import { useQuery } from '@tanstack/react-query';
+import CarouselImg from './CarouselImg';
 
 function ImgSlider() {
   const { data } = useQuery({ queryKey: ['slider'], queryFn: api.getViewdSliderImages });
@@ -14,12 +15,13 @@ function ImgSlider() {
     showArrows: false,
     showThumbs: false,
     showStatus: false,
+    emulateTouch: false,
   };
   return (
     <Wrapper>
       <Carousel {...settings}>
         {data?.map((image) => (
-          <Imgae src={image.imageUrl} width={1920} height={1080} alt="플레이브 이미지" />
+          <CarouselImg key={image.id} image={image} />
         ))}
       </Carousel>
     </Wrapper>
@@ -29,12 +31,6 @@ function ImgSlider() {
 const Wrapper = styled.div`
   width: 100%;
   aspect-ratio: 1920 / 1080;
-`;
-
-const Imgae = styled.img`
-  width: 1920px;
-  height: 1080px;
-  object-fit: fill;
 `;
 
 export default ImgSlider;

--- a/apps/asterum_traveler-app/src/components/report/PostBox.tsx
+++ b/apps/asterum_traveler-app/src/components/report/PostBox.tsx
@@ -1,0 +1,61 @@
+import { Report, ReportType } from '@asterum/types';
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+interface PostBoxProps {
+  report: Report;
+}
+
+function PostBox({ report }: PostBoxProps) {
+  const navigate = useNavigate();
+  const [loaded, setLoaded] = useState<boolean>(false);
+
+  const goToReportDetail = (reportId: string, reportType: ReportType) => {
+    navigate(`${reportType}/${reportId}`);
+  };
+
+  return (
+    <Wrapper
+      initial={{ backgroundColor: 'var(--placeholder)' }}
+      animate={{ backgroundColor: loaded ? 'transparent' : 'var(--placeholder)' }}
+      transition={{ duration: 0.7 }}
+      onClick={() => goToReportDetail(report.id, report.reportType)}
+    >
+      <motion.img
+        src={report.reportThumbnail}
+        width={388}
+        height={388}
+        alt={'리포트 이미지'}
+        loading="lazy"
+        decoding="async"
+        onLoad={() => {
+          setLoaded(true);
+        }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: loaded ? 1 : 0 }}
+        transition={{ duration: 0.7 }}
+      />
+    </Wrapper>
+  );
+}
+
+export default PostBox;
+
+const Wrapper = styled(motion.div)`
+  width: 100%;
+  aspect-ratio: 1;
+  background-color: var(--placeholder);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+
+  & > img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+`;

--- a/apps/asterum_traveler-app/src/components/report/ProductBox.tsx
+++ b/apps/asterum_traveler-app/src/components/report/ProductBox.tsx
@@ -8,6 +8,8 @@ import { IncludedProduct, Product } from '@asterum/types';
 import { useQuery } from '@tanstack/react-query';
 import * as api from '../../shared/services/reportService';
 import { sortMembers } from '../../shared/utils';
+import { useState } from 'react';
+import { motion } from 'framer-motion';
 
 const MEMBER_ICON = {
   yejun: yejunIcon,
@@ -22,6 +24,8 @@ interface ProductBoxProps {
 }
 
 function ProductBox({ includedProduct: { productId, members } }: ProductBoxProps) {
+  const [loaded, setLoaded] = useState<boolean>(false);
+
   const { data } = useQuery<Product>({
     queryKey: ['product', productId],
     queryFn: async () => {
@@ -37,6 +41,12 @@ function ProductBox({ includedProduct: { productId, members } }: ProductBoxProps
         src={data?.productThumbnail}
         alt="제품 이미지"
         loading="lazy"
+        onLoad={() => setLoaded(true)}
+        initial={{ opacity: 0 }}
+        animate={{
+          opacity: loaded ? 1 : 0,
+        }}
+        transition={{ duration: 0.3 }}
       />
       <ProductInfoBox>
         <ProductName className="text-overflow-2">{data?.productName}</ProductName>
@@ -64,7 +74,7 @@ const Wrapper = styled.div`
   gap: 16px;
 `;
 
-const ProductTumbnail = styled.img`
+const ProductTumbnail = styled(motion.img)`
   width: 100%;
   aspect-ratio: 1;
   object-fit: cover;

--- a/apps/asterum_traveler-app/src/pages/report/ReportImagePage.tsx
+++ b/apps/asterum_traveler-app/src/pages/report/ReportImagePage.tsx
@@ -3,6 +3,8 @@ import MemberBox from '../../components/report/MemberBox';
 import ProductBox from '../../components/report/ProductBox';
 import { Report } from '@asterum/types';
 import { ALL_MEMBERS } from '../../shared/constants';
+import { useState } from 'react';
+import { motion } from 'framer-motion';
 
 interface ReportImagePageProps {
   reportData: Report;
@@ -11,9 +13,22 @@ interface ReportImagePageProps {
 function ReportImagePage({ reportData }: ReportImagePageProps) {
   const { reportThumbnail, reportMembers, reportDateDisplay, imageTags, includedProducts } =
     reportData;
+  const [loaded, setLoaded] = useState<boolean>(false);
+
   return (
     <Wrapper>
-      <Thumbnail width="540" src={reportThumbnail} alt="리포트 이미지"></Thumbnail>
+      <Thumbnail
+        width="540"
+        src={reportThumbnail}
+        alt="리포트 이미지"
+        onLoad={() => {
+          setLoaded(true);
+        }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: loaded ? 1 : 0 }}
+        transition={{ duration: 0.3 }}
+      />
+
       <InfoContainer>
         <Members>
           {ALL_MEMBERS.map((member) => {
@@ -47,8 +62,9 @@ const Wrapper = styled.div`
   user-select: none;
 `;
 
-const Thumbnail = styled.img`
+const Thumbnail = styled(motion.img)`
   flex: 0 0 540px;
+
   width: 540px;
   object-fit: contain;
 `;

--- a/apps/asterum_traveler-app/src/shared/utils.ts
+++ b/apps/asterum_traveler-app/src/shared/utils.ts
@@ -45,3 +45,19 @@ export const sortMembers = (members: Member[]): Member[] => {
 
   return members.sort((a, b) => (orderMap.get(a) ?? Infinity) - (orderMap.get(b) ?? Infinity));
 };
+
+export const getRowCountForInfiniteScroll = (): number => {
+  const screenArea = window.innerWidth * window.innerHeight;
+  const cellArea = Math.pow(window.innerWidth / 4, 2);
+  const cellRowCount = Math.ceil(screenArea / cellArea / 4);
+
+  return cellRowCount + 1;
+};
+
+export const getListMinHeight = (cellHeight: number = 388): number => {
+  const screenArea = window.innerWidth * window.innerHeight;
+  const cellArea = Math.pow(window.innerWidth / 4, 2);
+  const cellRowCount = Math.ceil(screenArea / cellArea / 4);
+
+  return cellRowCount * cellHeight;
+};

--- a/packages/types/interfaces/report.interface.ts
+++ b/packages/types/interfaces/report.interface.ts
@@ -29,7 +29,7 @@ export type IncludedProduct = { productId: string; members: Member[] };
 
 export interface ReportBase {
   reportType: ReportType; // 'image' | 'live'
-  category: ReportCategory;
+  category: ReportCategory[];
   reportMembers: Member[];
   reportThumbnail: string;
   includedProducts: IncludedProduct[];


### PR DESCRIPTION
- 뷰 높이 계산해서 가져올 개수 계산
- 이미지 자연스럽게 보여주게 애니메이션 추가
- [x] 리포트 리스트
- [x] 카드 리스트
- [x] 어드민 리포트 추가 페이지 제품 선택시 제품 브랜드도 보이게 수정
- [x] 리포트 날짜별로 정렬
- [x] 리포트 타입 여러개 가능하게 타입 배열로 변경

---

- 페이지네이션을 위해 useQuery 대신 useInfiniteQuery로 변경 [useInfiniteQuery](https://tanstack.com/query/v4/docs/framework/react/reference/useInfiniteQuery)
- 무한 스크롤 구현을 위해 IntersectionObserver 사용

IntersectionObserver 참고
[실전 Infinite Scroll with React](https://tech.kakaoenterprise.com/149)
[IntersectionObserver Mdn](https://developer.mozilla.org/ko/docs/Web/API/IntersectionObserver)

close #37
