### PR TITLE
[App/#44] 리포트에서 카테고리 변경시 카테고리 셀 크기 변경되는 오류

### DIFF
--- a/apps/asterum_traveler-app/src/pages/report/ReportListPage.tsx
+++ b/apps/asterum_traveler-app/src/pages/report/ReportListPage.tsx
@@ -174,6 +174,7 @@ const PostContainer = styled.div<{ minHeight: number }>`
   margin: auto;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(auto-fill, 388px);
   gap: 16px;
   min-height: ${(props) => `${props.minHeight}px`};
 `;


### PR DESCRIPTION
### 문제 발생
리포트 카테고리 변경시 리포트 셀 크기가 커짐

### 문제 원인
infinite scroll 추가로 스크롤이 제일 하단에 오게 리스트에 min-height를 넣어줌. 그리고 grid-template-rows를 따로 추가해주지 않음

close #44

